### PR TITLE
Link command rework

### DIFF
--- a/mod.ts
+++ b/mod.ts
@@ -21,7 +21,6 @@ await new Command()
   .command("help", new HelpCommand())
   .command("completions", new CompletionsCommand())
   .command("link", link)
-  .option("-k, --key <value:string>", "Your API Key") // TODO(@oganexon): move key option to args
   .command("init", init)
   .command("publish", publish)
   .command("update", update)

--- a/src/commands/link.ts
+++ b/src/commands/link.ts
@@ -19,4 +19,4 @@ export const link = new Command<Options, Arguments>()
 
 type Arguments = [string];
 
-interface Options {}
+type Options = {}

--- a/src/commands/link.ts
+++ b/src/commands/link.ts
@@ -6,19 +6,17 @@ import { version } from "../version.ts";
  * Provided a key, the `link` commands creates
  * a persistent file on the host os to save
  * the API key to. */
-async function linkCommand() {
-  if (Deno.args.length < 3) {
-    log.critical(
-      "You need to pass in your API key! To do this, add `--key <your_key>` to the end of this command.",
-    );
-    Deno.exit(1);
-  }
-
-  await writeAPIKey(Deno.args[2]);
+async function linkCommand(options: Options, key: string) {
+  await writeAPIKey(key);
   log.info(`Successfully updated ${KEY_FILE} with your key!`);
 }
 
-export const link = new Command()
+export const link = new Command<Options, Arguments>()
   .version(version)
   .description("Links your nest.land API key to the CLI")
+  .arguments("<key:string>")
   .action(linkCommand);
+
+type Arguments = [string];
+
+interface Options {}

--- a/src/commands/link.ts
+++ b/src/commands/link.ts
@@ -19,4 +19,4 @@ export const link = new Command<Options, Arguments>()
 
 type Arguments = [string];
 
-type Options = {}
+type Options = {};

--- a/src/commands/publish.ts
+++ b/src/commands/publish.ts
@@ -75,7 +75,9 @@ async function checkREADME(config: Config) {
       log.warning(
         `Your readme contains old import URLs from your project using deno.land/x/${name}.`,
       );
-      log.warning(`You can change these to https://x.nest.land/${name}@VERSION`);
+      log.warning(
+        `You can change these to https://x.nest.land/${name}@VERSION`,
+      );
     }
   } catch (_) {
     log.warning("Could not open the README for url checking...");


### PR DESCRIPTION
This was the only option and there is no arg right now.

Old syntax:
```sh
eggs link --key <key>
```
New syntax:
```sh
eggs link <key>
```

Tests need to be updated.