### PR TITLE
fix: deps & dry publish

### DIFF
--- a/egg.json
+++ b/egg.json
@@ -6,6 +6,7 @@
     "repository": "https://github.com/nestdotland/nest.land",
     "files": [
         "./mod.ts",
+        "./deps.ts",
         "./src/**/*",
         "./README.md"
     ]

--- a/src/commands/publish.ts
+++ b/src/commands/publish.ts
@@ -203,6 +203,10 @@ async function publishCommand({ dry }: { dry: boolean }) {
   if (dry) {
     log.info("This was a dry run, the resulting module is:");
     console.error(module);
+    log.info("The matched file were:");
+    matched.forEach(file => {
+      console.log(` - ${file.path}`);
+    });
     Deno.exit(1);
   }
 
@@ -224,7 +228,7 @@ async function publishCommand({ dry }: { dry: boolean }) {
   log.info(`Successfully published ${bold(egg.name)}!`);
 
   log.info("Files uploaded: ");
-  Object.entries(pieceResponse.files).map((el) => {
+  Object.entries(pieceResponse.files).forEach((el) => {
     console.log(` - ${el[0]} -> ${bold(`${ENDPOINT}/${egg.name}${el[0]}`)}`);
   });
 


### PR DESCRIPTION
added deps.ts to egg.json and added the ability to see matched file during a dry run of publish (`eggs publish --dry`)