### PR TITLE
--bump & --version in eggs publish

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+git-ignore
+
 .idea/
 .vscode/
 

--- a/deps.ts
+++ b/deps.ts
@@ -52,14 +52,16 @@ export {
   Command,
   HelpCommand,
   CompletionsCommand,
-} from "https://x.nest.land/cliffy@0.11.0/packages/command/mod.ts";
+} from "https://x.nest.land/cliffy@0.11.1/packages/command/mod.ts";
 
 export {
   Input,
   Confirm,
   Select,
   List,
-} from "https://x.nest.land/cliffy@0.11.0/packages/prompt/mod.ts";
+} from "https://x.nest.land/cliffy@0.11.1/packages/prompt/mod.ts";
+
+export { IFlagArgument, IFlagOptions } from 'https://x.nest.land/cliffy@0.11.1/flags.ts';
 
 export * as semver from "https://deno.land/x/semver@v1.0.0/mod.ts";
 

--- a/deps.ts
+++ b/deps.ts
@@ -35,6 +35,7 @@ export {
   red,
   reset,
   setColorEnabled,
+  italic,
   underline,
   yellow,
 } from "https://deno.land/std@v0.61.0/fmt/colors.ts";

--- a/src/commands/publish.ts
+++ b/src/commands/publish.ts
@@ -282,7 +282,7 @@ function releaseType(
 ): string {
   if (!releaseTypes.includes(value)) {
     throw new Error(
-      `Option --${option.name} must be a valid release type but got: ${value}`,
+      `Option --${option.name} must be a valid release type but got: ${value}.\nAccepted values are ${releaseTypes.join(", ")}.`,
     );
   }
   return value;
@@ -295,7 +295,7 @@ function versionType(
 ): string {
   if (!semver.valid(value)) {
     throw new Error(
-      `Option --${option.name} must be a valid version but got: ${value}`,
+      `Option --${option.name} must be a valid version but got: ${value}.\nVersion must follow Semantic Versioning 2.0.0.`,
     );
   }
   return value;
@@ -314,7 +314,7 @@ export const publish = new Command()
   )
   .option(
     "--version <value:version>",
-    "Update the given version.",
+    "Update to the given version.",
     { conflicts: ["bump"] },
   )
   /* .option("--patch", "Bump the version up to the next patch version.", { conflicts: conflict("patch") })

--- a/src/commands/publish.ts
+++ b/src/commands/publish.ts
@@ -5,11 +5,11 @@ import {
   existsSync,
   expandGlobSync,
   green,
+  italic,
   log,
   relative,
   resolve,
   semver,
-  underline,
   walkSync,
   IFlagArgument,
   IFlagOptions,
@@ -25,7 +25,7 @@ import { Ignore } from "../context/ignore.ts";
 
 import { getAPIKey } from "../keyfile.ts";
 import { version } from "../version.ts";
-import { setupLog } from "../log.ts";
+import { setupLog, highlight } from "../log.ts";
 
 interface File {
   fullPath: string;
@@ -76,10 +76,14 @@ async function checkREADME(config: Config) {
     readme = readme.toLowerCase();
     if (readme.includes(`://deno.land/x/${name}`)) {
       log.warning(
-        `Your readme contains old import URLs from your project using deno.land/x/${name}.`,
+        `Your readme contains old import URLs from your project using ${
+          highlight(`deno.land/x/${name}`)
+        }.`,
       );
       log.warning(
-        `You can change these to https://x.nest.land/${name}@VERSION`,
+        `You can change these to ${
+          highlight("https://x.nest.land/${name}@VERSION")
+        }`,
       );
     }
   } catch {
@@ -95,7 +99,7 @@ async function checkFmt(config: Config) {
   if (formatStatus.success) {
     log.info("Formatted your code.");
   } else {
-    log.error("`deno fmt` returned a non-zero code.");
+    log.error(`${italic("deno fmt")} returned a non-zero code.`);
   }
 }
 
@@ -176,7 +180,9 @@ async function publishCommand(options: Options) {
   let apiKey = await getAPIKey();
   if (!apiKey) {
     log.error(
-      "No API Key file found. You can add one using `eggs link <api key>. You can create one on https://nest.land",
+      `No API Key file found. You can add one using eggs ${
+        italic("link <api key>")
+      }. You can create one on ${highlight("https://nest.land")}`,
     );
     return;
   }
@@ -271,15 +277,13 @@ async function publishCommand(options: Options) {
   log.info(
     green(
       "You can now find your package on our registry at " +
-        bold(`https://nest.land/package/${egg.name}\n`),
+        highlight(`https://nest.land/package/${egg.name}\n`),
     ),
   );
   log.info(
     `Add this badge to your README to let everyone know:\n\n ${
-      underline(
-        bold(
-          `[![nest badge](https://nest.land/badge.svg)](https://nest.land/package/${egg.name})`,
-        ),
+      highlight(
+        `[![nest badge](https://nest.land/badge.svg)](https://nest.land/package/${egg.name})`,
       )
     }`,
   );
@@ -346,13 +350,4 @@ export const publish = new Command<Options, []>()
     "Update to the given version.",
     { conflicts: ["bump"] },
   )
-  /* .option("--patch", "Bump the version up to the next patch version.", { conflicts: conflict("patch") })
-  .option("--minor", "Bump the version up to the next minor version.", { conflicts: conflict("minor") })
-  .option("--major", "Bump the version up to the next major version.", { conflicts: conflict("major") })
-  .option("--pre", "Increment the prerelease version.", { conflicts: conflict("pre") })
-  .option("--prepatch", "Bump the version up to the next patch version and down to a prerelease.", { conflicts: conflict("prepatch") })
-  .option("--preminor", "Bump the version up to the next minor version and down to a prerelease.", { conflicts: conflict("preminor") })
-  .option("--premajor", "Bump the version up to the next major version and down to a prerelease.", { conflicts: conflict("premajor") })
-  .option("--prerelease", "Increment the prerelease version or increment the patch version from a non-prerelease version.", { conflicts: conflict("prerelease") }) */
-  // .action(() => {});
   .action(publishCommand);

--- a/src/log.ts
+++ b/src/log.ts
@@ -144,14 +144,14 @@ export async function handleError(err: Error) {
   await writeLogFile();
   log.info(
     `If you think this is a bug, please open a bug report at ${
-      underline(bold("https://github.com/nestdotland/eggs/issues/new/choose"))
+      highlight("https://github.com/nestdotland/eggs/issues/new/choose")
     } with the information provided in ${
-      underline(bold(resolve(Deno.cwd(), DEBUG_LOG_FILE)))
+      highlight(resolve(Deno.cwd(), DEBUG_LOG_FILE))
     }`,
   );
   log.info(
     `Visit ${
-      underline(bold("https://docs.nest.land/eggs/"))
+      highlight("https://docs.nest.land/eggs/")
     } for documentation about this command.`,
   );
 }
@@ -160,4 +160,8 @@ const colorRegex = /\x1B[[(?);]{0,2}(;?\d)*./g;
 
 export function stripANSII(msg: string) {
   return msg.replace(colorRegex, "");
+}
+
+export function highlight(msg: string) {
+  return underline(bold(msg));
 }


### PR DESCRIPTION
## Options

You can use several options:
```shell script
eggs publish --bump minor
eggs publish --version 1.4.2
```

### --bump

Increment the version by the given release type.

 - patch - Bump the version up to the next patch version.
 - minor - Bump the version up to the next minor version.
 - major - Bump the version up to the next major version.
 - pre - Increment the prerelease version.
 - prepatch - Bump the version up to the next patch version and down to a prerelease.
 - preminor - Bump the version up to the next minor version and down to a prerelease.
 - premajor - Bump the version up to the next major version and down to a prerelease.
 - prerelease - Increment the prerelease version or increment the patch version from a non-prerelease version.

### --version

Update to the given version.

Version must follow [Semantic Versioning 2.0.0](https://semver.org/).