### PR TITLE
bump version to 0.2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@
 **Note: You need to upgrade to Deno v1.2.0 or newer in order to use our CLI.**
 
 ```shell script
-deno install -A -f --unstable -n eggs https://x.nest.land/eggs@0.1.10/mod.ts
+deno install -A -f --unstable -n eggs https://x.nest.land/eggs@0.2.0/mod.ts
 ```
 
 For more information, see the [documentation](https://docs.nest.land/).

--- a/src/commands/publish.ts
+++ b/src/commands/publish.ts
@@ -348,7 +348,7 @@ export const publish = new Command<Options, []>()
   )
   .option(
     "--version <value:version>",
-    "Update to the given version.",
+    "Set the version.",
     { conflicts: ["bump"] },
   )
   .action(publishCommand);

--- a/src/commands/update.ts
+++ b/src/commands/update.ts
@@ -77,12 +77,14 @@ async function updateGlobalModules(
       latestRelease,
     );
 
+    const options = newArgs.filter((x) => x !== "-f");
+
     const installation = Deno.run({
       cmd: [
         "deno",
         "install",
         "-f",
-        ...newArgs,
+        ...options,
       ],
     });
 

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,1 +1,1 @@
-export const version = "0.1.10"; // TODO(@qu4k): ugly
+export const version = "0.2.0"; // TODO(@qu4k): ugly


### PR DESCRIPTION
- Fixed install command
- Changed std mirror
- Added `--bump` & `--version` to publish command
- Fixed default options for init command
- Changed internal logger
- Added `--debug` & `--output-log` everywhere in the CLI
- Added support for `.eggignore`
- Removed `--key` in link command
- Refactor most of the codebase

@t8 can you correct this draft changelog if I've made mistakes or misspelled my sentences?
