### PR TITLE
Display the correspondig help of a sub-command after an error

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -3,19 +3,34 @@ name: Lint
 on: [push, pull_request]
 
 jobs:
-  lint:
-    name: Lint source
+  fmt:
+    name: deno fmt
+
     runs-on: ubuntu-latest
     timeout-minutes: 60
-    steps:
-    - name: Setup repo
-      uses: actions/checkout@v2
-      
-    - name: Setup Deno
-      uses: denolib/setup-deno@v2
 
-    - name: Check formatting
-      run: deno fmt --check
-    
-    - name: Run linter
-      run: deno lint --unstable
+    steps:
+      - name: Setup repo
+        uses: actions/checkout@v2
+
+      - name: Setup Deno
+        uses: denolib/setup-deno@v2
+
+      - name: Check formatting
+        run: deno fmt --check
+
+  lint:
+    name: deno lint
+
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+
+    steps:
+      - name: Setup repo
+        uses: actions/checkout@v2
+
+      - name: Setup Deno
+        uses: denolib/setup-deno@v2
+
+      - name: Run linter
+        run: deno lint --unstable

--- a/.github/workflows/ship.yml
+++ b/.github/workflows/ship.yml
@@ -1,9 +1,13 @@
 name: Ship
 
 on:
-  push:
-    branches: [master]
- 
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Version"
+        required: true
+
+
 jobs:
   release:
     runs-on: ubuntu-latest
@@ -14,10 +18,10 @@ jobs:
       - name: Setup Deno
         uses: denolib/setup-deno@v2
 
-      - name: Publish eggs
+      - name: Publish module
         run: |
-          deno run -A --unstable mod.ts link ${{ secrets.NESTAPIKEY }}
-          deno run -A --unstable mod.ts publish
+          deno run -A --unstable https://x.nest.land/eggs@0.2.1/mod.ts link ${{ secrets.NESTAPIKEY }}
+          deno run -A --unstable https://x.nest.land/eggs@0.2.1/mod.ts publish --version ${{ github.event.inputs.version }}
 
       - name: Draft release
         uses: release-drafter/release-drafter@v5

--- a/.github/workflows/ship.yml
+++ b/.github/workflows/ship.yml
@@ -1,11 +1,8 @@
 name: Ship
 
 on:
-  workflow_dispatch:
-    inputs:
-      version:
-        description: "Version"
-        required: true
+  push:
+    branches: [master]
 
 
 jobs:
@@ -18,10 +15,10 @@ jobs:
       - name: Setup Deno
         uses: denolib/setup-deno@v2
 
-      - name: Publish module
+      - name: Publish eggs
         run: |
-          deno run -A --unstable https://x.nest.land/eggs@0.2.1/mod.ts link ${{ secrets.NESTAPIKEY }}
-          deno run -A --unstable https://x.nest.land/eggs@0.2.1/mod.ts publish --version ${{ github.event.inputs.version }}
+          deno run -A --unstable mod.ts link ${{ secrets.NESTAPIKEY }}
+          deno run -A --unstable mod.ts publish
 
       - name: Draft release
         uses: release-drafter/release-drafter@v5

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,46 +1,52 @@
 name: Test
 
-on: 
+on:
   push:
   pull_request:
   schedule:
-    - cron: '0 9 * * *'
+    - cron: "0 9 * * *"
 
 jobs:
   stable:
     name: Deno Stable
+
     runs-on: ${{ matrix.os }}
     timeout-minutes: 60
+
     strategy:
       fail-fast: false
       matrix:
         os: [macOS-latest, windows-latest, ubuntu-latest]
-    steps:
-    - name: Setup repo
-      uses: actions/checkout@v2
-      
-    - name: Setup Deno
-      uses: denolib/setup-deno@v2
 
-    - name: Run tests
-      run: deno test -A --unstable
+    steps:
+      - name: Setup repo
+        uses: actions/checkout@v2
+
+      - name: Setup Deno
+        uses: denolib/setup-deno@v2
+
+      - name: Run tests
+        run: deno test -A --unstable
 
   nightly:
     name: Deno Nightly
+
     runs-on: ${{ matrix.os }}
     timeout-minutes: 60
+
     strategy:
       fail-fast: false
       matrix:
         os: [macOS-latest, windows-latest, ubuntu-latest]
-    steps:
-    - name: Setup repo
-      uses: actions/checkout@v2
-      
-    - name: Setup Deno
-      uses: denolib/setup-deno@master
-      with:
-        deno-version: nightly
 
-    - name: Run tests
-      run: deno test -A --unstable
+    steps:
+      - name: Setup repo
+        uses: actions/checkout@v2
+
+      - name: Setup Deno
+        uses: denolib/setup-deno@v2
+        with:
+          deno-version: nightly
+
+      - name: Run tests
+        run: deno test -A --unstable

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -43,4 +43,4 @@ jobs:
         deno-version: nightly
 
     - name: Run tests
-      run: deno-nightly test -A --unstable
+      run: deno test -A --unstable

--- a/mod.ts
+++ b/mod.ts
@@ -16,6 +16,8 @@ import {
   errorOccurred,
 } from "./src/log.ts";
 
+const commands = { link, init, publish, update, install, upgrade };
+
 await setupLog();
 
 const eggs = new Command<DefaultOptions, []>()
@@ -60,7 +62,12 @@ try {
       /^(Unknown option:|Unknown command:|Option --|Missing value for option:|Missing argument\(s\):)/,
     )
   ) {
-    eggs.help();
+    const command = Deno.args[0] as keyof typeof commands;
+    if (command in commands) {
+      commands[command].help();
+    } else {
+      eggs.help();
+    }
     log.error(err.message);
   } else {
     await handleError(err);


### PR DESCRIPTION
With the creation of the custom logger, when an error occurred the global help was displayed instead of the help for the sub-command. This is now fixed.

Before:
![image](https://user-images.githubusercontent.com/52361520/90314274-beb28f80-df12-11ea-8ec0-0a4f70d70773.png)

After:
![image](https://user-images.githubusercontent.com/52361520/90314259-aa6e9280-df12-11ea-9ef5-1e8f1a5208e4.png)
