### PR TITLE
Fix a typo in dry run output

### DIFF
--- a/src/commands/publish.ts
+++ b/src/commands/publish.ts
@@ -295,7 +295,7 @@ async function publishCommand(options: Options, name?: string) {
 
   if (options.dryRun) {
     log.info(`This was a dry run, the resulting module is:`, module);
-    log.info("The matched file were:");
+    log.info("The matched files were:");
     matched.forEach((file) => {
       log.info(` - ${file.path}`);
     });


### PR DESCRIPTION
This PR fixes a tiny typographical error when `eggs publish` is ran with `-d`/`--dry-run`:
```diff
- log.info("The matched file were:");
+ log.info("The matched files were:");
```