### PR TITLE
Can't link API key on Windows

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,7 +35,7 @@ jobs:
 
       - name: Eggs release test
         run: |
-          deno run -A --unstable mod.ts link ${{ secrets.NESTAPIKEY }} -do
+          deno run -A --unstable mod.ts link ${{ secrets.NESTAPIKEY || "null" }} -do
           deno run -A --unstable mod.ts publish eggs --dry-run -do --ignore "extends .gitignore" --version ${{ env.EGGS_VERSION }}
         
       - uses: actions/upload-artifact@v2
@@ -74,7 +74,7 @@ jobs:
 
       - name: Eggs release test
         run: |
-          deno run -A --unstable mod.ts link ${{ secrets.NESTAPIKEY }} -do
+          deno run -A --unstable mod.ts link ${{ secrets.NESTAPIKEY || "null" }} -do
           deno run -A --unstable mod.ts publish eggs --dry-run -do --ignore "extends .gitignore" --version ${{ env.EGGS_VERSION }}
       
       - uses: actions/upload-artifact@v2

--- a/src/environment.ts
+++ b/src/environment.ts
@@ -1,7 +1,6 @@
 export function envHOMEDIR(): string {
-  return Deno.env.get("HOME") ??
-    Deno.env.get("HOMEPATH") ??
-    Deno.env.get("USERPROFILE") ??
+  return Deno.env.get("HOME") ?? // for linux / mac 
+    Deno.env.get("USERPROFILE") ?? // for windows 
     "/";
 }
 


### PR DESCRIPTION
``HOMEPATH`` is not a currect dir path in windows .. because ``HOMEPATH`` in the environment variables in Windows returns  \Users\{usename} and this path is invalid for creating or reading the .nest-api-key file in Windows.

I get an error every time I try to create or link a .nest-api-key file via the command prompt and I also get a similar error when trying to deploy the module in nest.land via eggs for the same reason that. The nest-api-key file cannot be read even if you create it and manually put the API key in it

the error  : [CRIT] An unexpected error occurred: "The system cannot find the path specified. (os error 3)"
**
./eggs-debug.log
** file
```txt
Arguments:
  link,api-key

Deno version:
  deno: 1.4.1
  v8: 8.7.75
  typescript: 4.0.2

Eggs version:
  0.2.2

Platform:
  x86_64-pc-windows-msvc

2020-09-21T11:54:59.680Z [DEBUG]    Key:  "api-key"
2020-09-21T11:54:59.709Z [CRITICAL] An unexpected error occurred: "The system cannot find the path specified. (os error 3)" "NotFound: The system cannot find the path specified. (os error 3)\n    at Object.jsonOpAsync (core.js:236:13)\n    at async open (deno:cli/rt/30_files.js:44:17)\n    at async Object.writeFile (deno:cli/rt/40_write_file.js:54:18)\n    at async writeAPIKey (keyfile.ts:23:3)\n    at async Command.linkCommand [as fn] (link.ts:15:3)\n    at async Command.execute (command.ts:796:9)\n    at async Command.parse (command.ts:731:14)\n    at async Command.parse (command.ts:688:14)\n    at async mod.ts:51:23"
```