### PR TITLE
Hotfixes (merge this before 0.2.3)

### DIFF
--- a/src/commands/publish.ts
+++ b/src/commands/publish.ts
@@ -162,9 +162,11 @@ async function checkUp(
       {
         cmd: typeof config.checkFormat === "string"
           ? config.checkFormat?.split(" ")
-          : ["deno", "fmt"].concat(matched.map((file) => file.fullPath).filter(
-            (path) => path.match(/\.(js|jsx|ts|tsx|json)$/),
-          )),
+          : ["deno", "fmt"].concat(
+            matched.map((file) => file.fullPath).filter(
+              (path) => path.match(/\.(js|jsx|ts|tsx|json)$/),
+            ),
+          ),
         stderr: "null",
         stdout: "null",
       },

--- a/src/commands/publish.ts
+++ b/src/commands/publish.ts
@@ -162,7 +162,9 @@ async function checkUp(
       {
         cmd: typeof config.checkFormat === "string"
           ? config.checkFormat?.split(" ")
-          : ["deno", "fmt"].concat(matched.map((file) => file.fullPath)),
+          : ["deno", "fmt"].concat(matched.map((file) => file.fullPath).filter(
+            (path) => path.match(/\.(js|jsx|ts|tsx|json)$/),
+          )),
         stderr: "null",
         stdout: "null",
       },

--- a/src/commands/publish.ts
+++ b/src/commands/publish.ts
@@ -28,13 +28,17 @@ import {
 } from "../context/config.ts";
 import { gatherContext } from "../context/context.ts";
 import { parseIgnore, extendsIgnore } from "../context/ignore.ts";
+import type { Ignore } from "../context/ignore.ts";
 import { MatchedFile, matchFiles, readFiles } from "../context/files.ts";
 
 import { getAPIKey } from "../keyfile.ts";
 import { version } from "../version/version.ts";
 import { setupLog, highlight, spinner } from "../log.ts";
 
-function ensureCompleteConfig(config: Partial<Config>): config is Config {
+function ensureCompleteConfig(
+  config: Partial<Config>,
+  ignore: Ignore | undefined,
+): config is Config {
   let isConfigComplete = true;
 
   if (!config.name) {
@@ -49,7 +53,7 @@ function ensureCompleteConfig(config: Partial<Config>): config is Config {
     isConfigComplete = false;
   }
 
-  if (!config.files && !config.ignore) {
+  if (!config.files && !ignore) {
     log.error(
       `Your module configuration must provide files to upload in the form of a ${
         italic("files")
@@ -268,14 +272,14 @@ async function publishCommand(options: Options, name?: string) {
 
   log.debug("Raw config:", egg);
 
-  if (!ensureCompleteConfig(egg)) return;
-
   // TODO(@oganexon): deprecate egg.ignore as Ignore
   const ignore = contextIgnore ||
     egg.ignore &&
       (Array.isArray(egg.ignore)
         ? await extendsIgnore(parseIgnore(egg.ignore.join()))
         : egg.ignore);
+
+  if (!ensureCompleteConfig(egg, ignore)) return;
 
   log.debug("Ignore:", ignore);
 

--- a/src/context/ignore.ts
+++ b/src/context/ignore.ts
@@ -85,10 +85,10 @@ export function parseIgnore(
     // Otherwise the pattern may also match at any level below the .gitignore level.
     if (line.replace(/\/$/, "").split("/").length === 1) {
       line = `**/${line}`;
-      // If there is a separator at the end of the pattern then the pattern will only match directories,
-      // otherwise the pattern can match both files and directories.
-      if (line.endsWith("/")) line = `${line}**`;
     }
+    // If there is a separator at the end of the pattern then the pattern will only match directories,
+    // otherwise the pattern can match both files and directories.
+    if (line.endsWith("/")) line = `${line}**`;
     try {
       const pattern = globToRegExp(line);
       if (accepts) {

--- a/src/context/ignore.ts
+++ b/src/context/ignore.ts
@@ -83,12 +83,11 @@ export function parseIgnore(
     // If there is a separator at the beginning or middle (or both) of the pattern,
     // then the pattern is relative to the directory level of the particular .gitignore file itself.
     // Otherwise the pattern may also match at any level below the .gitignore level.
-    if (line.replace(/\/$/, "").split("/").length === 1) {
-      line = `**/${line}`;
-    }
+    if (line.replace(/\/$/, "").split("/").length === 1) line = `**/${line}`;
     // If there is a separator at the end of the pattern then the pattern will only match directories,
     // otherwise the pattern can match both files and directories.
     if (line.endsWith("/")) line = `${line}**`;
+
     try {
       const pattern = globToRegExp(line);
       if (accepts) {


### PR DESCRIPTION
Hotfixes: Format only js, ts files (--check-format) + allow for .eggignore
- With the current settings, `--check-format` could cause files as .gitignore to be formatted.
- `.eggignore` could not be used without `--ignore`