### PR TITLE
Typo in release workflow

### DIFF
--- a/.github/workflows/ship.yml
+++ b/.github/workflows/ship.yml
@@ -33,5 +33,5 @@ jobs:
         # TODO(@oganexon): remove --description after next release
         run: |
           deno run -A --unstable mod.ts link ${{ secrets.NESTAPIKEY }}
-          deno run -A --unstable mod.ts publish eggs --ignore "extends .gitignore" --version ${{ env.EGGS_VERSION }} --description "The CLI used to publish and update modules in nest.land.
+          deno run -A --unstable mod.ts publish eggs --ignore "extends .gitignore" --version ${{ env.EGGS_VERSION }} --description "The CLI used to publish and update modules in nest.land."
 


### PR DESCRIPTION
https://github.com/nestdotland/eggs/runs/1150599156?check_suite_focus=true#step:7:226
```
/home/runner/work/_temp/08efac1b-3916-468c-bae8-ec23ec2adaab.sh: line 2: unexpected EOF while looking for matching `"'
```