### PR TITLE
Entry file was duplicated in the files field after publication

### DIFF
--- a/src/api/fetch.ts
+++ b/src/api/fetch.ts
@@ -14,7 +14,9 @@ export async function fetchResource<T>(query: string): Promise<T | undefined> {
 }
 
 export async function fetchModule(name: string): Promise<Module | undefined> {
-  let module: IModule | undefined = await fetchResource(`/api/package/${name}`);
+  const module: IModule | undefined = await fetchResource(
+    `/api/package/${name}`,
+  );
   if (!module) return undefined;
   return new Module(module);
 }

--- a/src/api/post.ts
+++ b/src/api/post.ts
@@ -51,7 +51,7 @@ export async function postPublishModule(
   key: string,
   module: PublishModule,
 ): Promise<PublishResponse | undefined> {
-  let response: PublishResponse | undefined = await postResource(
+  const response: PublishResponse | undefined = await postResource(
     "/api/publish",
     { "Authorization": key },
     module,
@@ -68,7 +68,7 @@ export async function postPieces(
   uploadToken: string,
   pieces: StringMap,
 ): Promise<PiecesResponse | undefined> {
-  let response: PiecesResponse | undefined = await postResource(
+  const response: PiecesResponse | undefined = await postResource(
     "/api/piece",
     { "X-UploadToken": uploadToken },
     {

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -31,7 +31,7 @@ export async function init(options: Options) {
 
   let currentConfig: Partial<Config> = {};
 
-  let configPath = await defaultConfig();
+  const configPath = await defaultConfig();
   if (configPath) {
     log.warning("An egg config file already exists...");
     const override = await Confirm.prompt("Do you want to override it?");

--- a/src/commands/update.ts
+++ b/src/commands/update.ts
@@ -61,8 +61,7 @@ export async function update(
    * Skips the dependency if it is not versioned (no need to try to update it) */
   const dependenciesToUpdate: Array<ModuleToUpdate> = [];
   for (const line of dependencyFileContents) {
-    const processedURL = parseURL(line);
-    const { name, parsedURL, registry, owner, version } = processedURL;
+    const { name, parsedURL, registry, owner, version } = parseURL(line);
 
     // TODO(@qu4k): edge case: dependency isn't a module, for example: from
     //  "https://x.nest.land/std@version.ts";, will return -> "version.ts";

--- a/src/commands/update.ts
+++ b/src/commands/update.ts
@@ -61,7 +61,8 @@ export async function update(
    * Skips the dependency if it is not versioned (no need to try to update it) */
   const dependenciesToUpdate: Array<ModuleToUpdate> = [];
   for (const line of dependencyFileContents) {
-    let { name, parsedURL, registry, owner, version } = parseURL(line);
+    const processedURL = parseURL(line);
+    const { name, parsedURL, registry, owner, version } = processedURL;
 
     // TODO(@qu4k): edge case: dependency isn't a module, for example: from
     //  "https://x.nest.land/std@version.ts";, will return -> "version.ts";

--- a/src/context/files.ts
+++ b/src/context/files.ts
@@ -24,9 +24,8 @@ export function matchFiles(
   let matched: MatchedFile[] = [];
 
   if (config.files) {
-    config.files.push(config.entry);
-    for (let file of config.files) {
-      let matches = [
+    for (const file of [config.entry, ...config.files]) {
+      const matches = [
         ...expandGlobSync(file, {
           root: Deno.cwd(),
           extended: true,

--- a/src/context/ignore_test.ts
+++ b/src/context/ignore_test.ts
@@ -4,7 +4,7 @@ import { parseIgnore } from "./ignore.ts";
 Deno.test({
   name: "internal | ignore | parsing",
   fn(): void {
-    let matched = parseIgnore(`
+    const matched = parseIgnore(`
 extends .gitignore
 extends ./dir/*
 .git/*

--- a/src/utilities/log.ts
+++ b/src/utilities/log.ts
@@ -61,7 +61,7 @@ class ConsoleHandler extends BaseHandler {
 
     if (detailedLog) {
       for (const arg of record.args) {
-        msg += ` ${Deno.inspect(arg, { depth: 10 })}`;
+        msg += ` ${Deno.inspect(arg, { depth: 10, colors: true })}`;
       }
     }
 
@@ -100,7 +100,7 @@ class FileHandler extends BaseHandler {
     msg += ` ${stripColor(record.msg)}`;
 
     for (const arg of record.args) {
-      msg += ` ${stripColor(Deno.inspect(arg, { depth: Infinity }))}`;
+      msg += ` ${Deno.inspect(arg, { depth: Infinity })}`;
     }
 
     return msg;


### PR DESCRIPTION
- fix: Entry file was duplicated in the files field after publication.
- fix: Module stability was not computed with semver rules.
- fix: Minor cosmetic formatting changes.
- fix: Updated code to work with `Deno@1.4.6`.