### PR TITLE
0.3.2

### DIFF
--- a/deps.ts
+++ b/deps.ts
@@ -9,7 +9,7 @@ export {
   join,
   relative,
   resolve,
-} from "https://x.nest.land/std@0.74.0/path/mod.ts";
+} from "https://x.nest.land/std@0.75.0/path/mod.ts";
 
 export {
   exists,
@@ -17,29 +17,29 @@ export {
   expandGlob,
   expandGlobSync,
   walkSync,
-} from "https://x.nest.land/std@0.74.0/fs/mod.ts";
+} from "https://x.nest.land/std@0.75.0/fs/mod.ts";
 
-export * as log from "https://x.nest.land/std@0.74.0/log/mod.ts";
+export * as log from "https://x.nest.land/std@0.75.0/log/mod.ts";
 
-export { LogRecord } from "https://x.nest.land/std@0.74.0/log/logger.ts";
+export { LogRecord } from "https://x.nest.land/std@0.75.0/log/logger.ts";
 
-export type { LevelName } from "https://x.nest.land/std@0.74.0/log/levels.ts";
-export { LogLevels } from "https://x.nest.land/std@0.74.0/log/levels.ts";
+export type { LevelName } from "https://x.nest.land/std@0.75.0/log/levels.ts";
+export { LogLevels } from "https://x.nest.land/std@0.75.0/log/levels.ts";
 
-export { BaseHandler } from "https://x.nest.land/std@0.74.0/log/handlers.ts";
+export { BaseHandler } from "https://x.nest.land/std@0.75.0/log/handlers.ts";
 
-export * from "https://x.nest.land/std@0.74.0/fmt/colors.ts";
+export * from "https://x.nest.land/std@0.75.0/fmt/colors.ts";
 
 export {
   assert,
   assertEquals,
   assertMatch,
-} from "https://x.nest.land/std@0.74.0/testing/asserts.ts";
+} from "https://x.nest.land/std@0.75.0/testing/asserts.ts";
 
 export {
   parse as parseYaml,
   stringify as stringifyYaml,
-} from "https://x.nest.land/std@0.74.0/encoding/yaml.ts";
+} from "https://x.nest.land/std@0.75.0/encoding/yaml.ts";
 
 /**************** cliffy ****************/
 export {
@@ -68,13 +68,15 @@ export * as base64 from "https://denopkg.com/chiefbiiko/base64@v0.2.0/mod.ts";
 
 /**************** hatcher ****************/
 export {
-  getLatestVersion,
+  latestVersion,
   NestLand,
   parseURL,
   UpdateNotifier,
-} from "https://x.nest.land/hatcher@0.9.2/mod.ts";
+} from "https://x.nest.land/hatcher@0.10.1/mod.ts";
 
-export { install as installHatcher } from "https://x.nest.land/hatcher@0.9.2/lib/cli.ts";
+export { isVersionUnstable } from "https://x.nest.land/hatcher@0.10.1/lib/utilities/utils.ts";
+
+export { install as installHatcher } from "https://x.nest.land/hatcher@0.10.1/lib/cli.ts";
 
 /**************** analyzer ****************/
 export type { DependencyTree } from "https://x.nest.land/analyzer@0.0.6/deno/tree.ts";

--- a/src/api/module_test.ts
+++ b/src/api/module_test.ts
@@ -17,7 +17,7 @@ Deno.test({
       ],
     });
 
-    const maze_generator = new Module({
+    const mazeGenerator = new Module({
       name: "maze_generator",
       owner: "TheWizardBear",
       description: "A module for generating mazes",
@@ -30,6 +30,6 @@ Deno.test({
     });
 
     assertEquals(eggs.getLatestVersion(), "0.1.9-rc1");
-    assertEquals(maze_generator.getLatestVersion(), "0.1.0-alpha.0");
+    assertEquals(mazeGenerator.getLatestVersion(), "0.1.0-alpha.0");
   },
 });

--- a/src/commands/info.ts
+++ b/src/commands/info.ts
@@ -9,10 +9,12 @@ import {
   green,
   italic,
   log,
+  magenta,
   parseURL,
   red,
   resolve,
   rgb24,
+  yellow,
 } from "../../deps.ts";
 import type { DefaultOptions } from "../commands.ts";
 import { version } from "../version.ts";
@@ -29,6 +31,8 @@ const format = {
   denoLand: cyan("deno.land"),
   github: blue("github.com"),
   denopkgCom: green("denopkg.com"),
+  skypack: magenta("cdn.skypack.dev"),
+  jspm: yellow("jspm.dev"),
 };
 
 /** Info Command. */
@@ -153,6 +157,12 @@ function beautifyDependency(dep: string) {
         return `${format.denopkgCom} ${bold(`${owner}/${name}`)} ${
           formatVersion(version)
         } ${formatPath(relativePath)}`;
+
+      case "cdn.skypack.dev":
+        return `${format.skypack} ${bold(name)} ${formatVersion(version)}`;
+
+      case "jspm.dev":
+        return `${format.jspm} ${bold(name)} ${formatVersion(version)}`;
 
       default:
         return dep;

--- a/src/commands/publish.ts
+++ b/src/commands/publish.ts
@@ -10,6 +10,7 @@ import {
   globToRegExp,
   gray,
   green,
+  isVersionUnstable,
   italic,
   join,
   log,
@@ -96,10 +97,6 @@ function ensureFiles(config: Config, matched: MatchedFile[]): boolean {
 
 async function deprecationWarnings(config: Config) {
   // no deprecated feature for the time being :)
-}
-
-function isVersionUnstable(v: string) {
-  return !((semver.major(v) === 0) || semver.prerelease(v));
 }
 
 function gatherOptions(

--- a/src/commands/update.ts
+++ b/src/commands/update.ts
@@ -1,7 +1,7 @@
 import {
   Command,
-  getLatestVersion,
   green,
+  latestVersion,
   log,
   parseURL,
   semver,
@@ -76,7 +76,7 @@ export async function update(
     }
 
     // Get latest release
-    const latestRelease = await getLatestVersion(registry, name, owner);
+    const latestRelease = await latestVersion(registry, name, owner);
 
     // Basic safety net
 

--- a/src/commands/upgrade.ts
+++ b/src/commands/upgrade.ts
@@ -7,7 +7,11 @@ import { setupLog } from "../utilities/log.ts";
 export async function upgrade(options: DefaultOptions) {
   await setupLog(options.debug);
 
-  const newVersion = await NestLand.getLatestVersion("eggs");
+  const newVersion = await NestLand.latestVersion("eggs");
+  if (!newVersion) {
+    log.error("Could not retrieve latest version.");
+    return;
+  }
   if (semver.eq(newVersion, version)) {
     log.info("You are already using the latest CLI version!");
     return;
@@ -18,11 +22,8 @@ export async function upgrade(options: DefaultOptions) {
       "deno",
       "install",
       "--unstable",
-      "-A",
-      "-f",
-      "-n",
-      "eggs",
-      `https://x.nest.land/eggs@${newVersion}/mod.ts`,
+      "-Afq",
+      `https://x.nest.land/eggs@${newVersion}/eggs.ts`,
     ],
     stdout: "piped",
     stderr: "piped",

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,1 +1,1 @@
-export const version = "0.3.1";
+export const version = "0.3.2";


### PR DESCRIPTION
- fix: stability function gave the opposite of the expected result #103 
- fix: change `mod.ts` to `eggs.ts` in upgrade command
- chore: update Hatcher & info command
- chore: update Drakefile (Githug actions deprecated use of `::set-path`)