### PR TITLE
feat: ✨ add indentation preservation logic

### DIFF
--- a/deps.ts
+++ b/deps.ts
@@ -84,3 +84,6 @@ export { dependencyTree } from "https://x.nest.land/analyzer@0.0.6/deno/tree.ts"
 
 /**************** wait ****************/
 export { Spinner, wait } from "https://deno.land/x/wait@0.1.12/mod.ts";
+
+/**************** detect-indent ****************/
+export { default as detectIndent } from "https://jspm.dev/detect-indent@7";

--- a/src/context/config.ts
+++ b/src/context/config.ts
@@ -85,8 +85,13 @@ export async function writeConfig(
       break;
     case ConfigFormat.JSON:
       const configPath = join(Deno.cwd(), "egg.json");
-      const currentConfigString = await Deno.readTextFile(configPath);
-      const { indent } = detectIndent(currentConfigString);
+
+      let indent = "  ";
+
+      if (await exists(configPath)) {
+        const currentConfigString = await Deno.readTextFile(configPath);
+        ({ indent } = detectIndent(currentConfigString));
+      }
 
       await writeJson(configPath, data, { indent });
       break;

--- a/src/context/config.ts
+++ b/src/context/config.ts
@@ -1,4 +1,5 @@
 import {
+  detectIndent,
   exists,
   extname,
   join,
@@ -83,7 +84,11 @@ export async function writeConfig(
       await writeYaml(join(Deno.cwd(), "egg.yml"), stringifyYaml(data));
       break;
     case ConfigFormat.JSON:
-      await writeJson(join(Deno.cwd(), "egg.json"), data, { spaces: 2 });
+      const configPath = join(Deno.cwd(), "egg.json");
+      const currentConfigString = await Deno.readTextFile(configPath);
+      const { indent } = detectIndent(currentConfigString);
+
+      await writeJson(configPath, data, { indent });
       break;
     default:
       throw new Error(`Unknown config format: ${format}`);

--- a/src/utilities/json.ts
+++ b/src/utilities/json.ts
@@ -3,7 +3,7 @@ type Replacer = (key: string, value: unknown) => unknown;
 
 export interface WriteJsonOptions extends Deno.WriteFileOptions {
   replacer?: Array<number | string> | Replacer;
-  spaces?: number | string;
+  indent?: string;
 }
 
 function serialize(
@@ -16,7 +16,7 @@ function serialize(
     const jsonString = JSON.stringify(
       object,
       options.replacer as string[],
-      options.spaces,
+      options.indent,
     );
     return `${jsonString}\n`;
   } catch (err) {


### PR DESCRIPTION
This is a relatively naive but small addition which "fixes" an issue I had with `eggs` for as long as I used it.
Basically, `eggs publish` overrides your `eggs.json`, even if there shouldn't really be any changes to your `eggs.json`. Which is fine though, I didn't want to change that part. The problem is, it formats and saves the config with a hard-coded indentation of two spaces. I use tab indentation for all my files though, so everytime after I used `publish`, I have to repair the indentation.

The implementation in this PR is "naive" because it reads the already present config file **again** before saving it, to detect the indent. Some day maybe someone can connect the location of where `eggs` reads the config file with the location of where it writes it, to avoid reading the config file twice. I wasn't easily able to and to be honest not really motivated as well, since this would include a bunch of added arguments throughout the whole `publish` logic. A maintainer might be better suited to make the decisions involved in this.

This PR uses https://github.com/sindresorhus/detect-indent, imported from https://jspm.dev/detect-indent@7 . Ideally we should either rewrite it and publish it on https://nest.land or convince sindresorhus to do so. But I think using https://jspm.dev with a pinned version is fine for now.