### PR TITLE
Provide better error reporting

### DIFF
--- a/src/api/post.ts
+++ b/src/api/post.ts
@@ -8,7 +8,7 @@ export async function postResource<T>(
   query: string,
   headers: StringMap,
   data: Record<string, unknown>,
-): Promise<T | undefined> {
+): Promise<T | Error> {
   // TODO(@qu4k): add test resource
   try {
     const response = await apiFetch(`${ENDPOINT}${query}`, {
@@ -20,11 +20,16 @@ export async function postResource<T>(
       body: JSON.stringify(data),
     });
 
-    if (!response || !response.ok) return undefined;
+    if (!response.ok) {
+      return new Error(
+        `The server respond with ${response.status} ${response.statusText}:\n` +
+          await response.text(),
+      );
+    }
     const value = await response.json();
     return value as T;
-  } catch {
-    return undefined;
+  } catch (e) {
+    return e;
   }
 }
 
@@ -50,8 +55,8 @@ export interface PublishModule extends Record<string, unknown> {
 export async function postPublishModule(
   key: string,
   module: PublishModule,
-): Promise<PublishResponse | undefined> {
-  const response: PublishResponse | undefined = await postResource(
+): Promise<PublishResponse | Error> {
+  const response: PublishResponse | Error = await postResource(
     "/api/publish",
     { "Authorization": key },
     module,
@@ -67,8 +72,8 @@ export interface PiecesResponse {
 export async function postPieces(
   uploadToken: string,
   pieces: StringMap,
-): Promise<PiecesResponse | undefined> {
-  const response: PiecesResponse | undefined = await postResource(
+): Promise<PiecesResponse | Error> {
+  const response: PiecesResponse | Error = await postResource(
     "/api/piece",
     { "X-UploadToken": uploadToken },
     {

--- a/src/commands/publish.ts
+++ b/src/commands/publish.ts
@@ -361,23 +361,25 @@ export async function publish(options: Options, name?: string) {
   }
 
   const uploadResponse = await postPublishModule(apiKey, module);
-  if (!uploadResponse) {
-    // TODO(@qu4k): provide better error reporting
-    throw new Error("Something broke when publishing... ");
+  if (uploadResponse instanceof Error) {
+    throw new Error(
+      `Something broke when publishing; ${uploadResponse.message}`,
+    );
   }
 
   const pieceResponse = await postPieces(
     uploadResponse.token,
     Object.entries(matchedContent).reduce((prev, [key, value]) => {
-      prev[key.substr(1)] = value;
+      prev[key.substring(1)] = value;
       return prev;
     }, {} as Record<string, string>),
   );
   // TODO(@oganexon): same, needs consistency
 
-  if (!pieceResponse) {
-    // TODO(@qu4k): provide better error reporting
-    throw new Error("Something broke when sending pieces... ");
+  if (pieceResponse instanceof Error) {
+    throw new Error(
+      `Something broke when sending pieces; ${pieceResponse.message}`,
+    );
   }
 
   const configPath = await defaultConfig();


### PR DESCRIPTION
Fixes <https://github.com/nestdotland/nest.land/issues/93#issuecomment-646298833>.

Previously, `eggs` shows error like `Something broke when publishing...` or `Something broke when sending pieces...` without any details.  This patch adds some more details like status code and response text into error messages.